### PR TITLE
Fix input sanitization deprecation warnings

### DIFF
--- a/src/code/class-i-order-terms.php
+++ b/src/code/class-i-order-terms.php
@@ -487,7 +487,7 @@ class I_Order_Terms
 		if ( !current_user_can( 'manage_categories' ) ) return;
 
 		// Fetch taxonomy name
-		$taxonomy = filter_input( INPUT_GET, 'taxonomy', FILTER_SANITIZE_STRING );
+		$taxonomy = filter_input( INPUT_GET, 'taxonomy', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		// Load assets only on taxonomy screen and when orderby is not selected
 		if ( empty( $_GET['orderby'] ) && !empty( $taxonomy ) && in_array( $taxonomy, $this->taxonomies ) ) {
@@ -582,7 +582,7 @@ class I_Order_Terms
 			exit( $this->ajax_response( 'error', __( 'Security check failed. Please reload the page and try again.', 'i-order-terms' ) ) );
 		}
 
-		$taxonomy = filter_input( INPUT_POST, 'taxonomy', FILTER_SANITIZE_STRING );
+		$taxonomy = filter_input( INPUT_POST, 'taxonomy', FILTER_SANITIZE_SPECIAL_CHARS );
 		$term_id = filter_input( INPUT_POST, 'term_id', FILTER_SANITIZE_NUMBER_INT );
 		$term_prev_id = filter_input( INPUT_POST, 'term_prev_id', FILTER_SANITIZE_NUMBER_INT );
 		$term_next_id = filter_input( INPUT_POST, 'term_next_id', FILTER_SANITIZE_NUMBER_INT );


### PR DESCRIPTION
This pull request updates the way taxonomy input is sanitized in the `class-i-order-terms.php` file to fix [deprecation warnings, from php 8.1](https://www.php.net/manual/en/filter.constants.php#constant.filter-sanitize-string). The main change is switching from `FILTER_SANITIZE_STRING` to `FILTER_SANITIZE_SPECIAL_CHARS` when retrieving the `taxonomy` parameter in both GET and POST requests.


**Security improvements:**

* Updated the sanitization filter for the `taxonomy` parameter from `FILTER_SANITIZE_STRING` to `FILTER_SANITIZE_SPECIAL_CHARS` in the `admin_assets()` method to better handle special characters and enhance security.
* Made the same update for the `taxonomy` parameter in the `ajax_order_terms()` method for POST requests.